### PR TITLE
Fetch requirejs from unpkg to avoid expired certificate error on build

### DIFF
--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -5,12 +5,12 @@ WORKDIR /usr/src/app
 RUN install_packages wget
 
 ENV JQUERY_VERSION=3.3.1
-ENV REQUIREJS_VERSION=2.3.5
+ENV REQUIREJS_VERSION=2.3.6
 ENV HIGHCHARTS_VERSION=7.0.3
 RUN mkdir -p static/js && \
     wget "https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js" -O static/js/jquery.min.js && \
     wget "https://code.highcharts.com/${HIGHCHARTS_VERSION}/highcharts.js" -O static/js/highcharts.js && \
-    wget "http://requirejs.org/docs/release/${REQUIREJS_VERSION}/minified/require.js" -O static/js/require.js
+    wget "https://unpkg.com/requirejs@${REQUIREJS_VERSION}/require.js" -O static/js/require.js
 
 # Copies the package.json first for better cache on later pushes
 COPY package.json package.json


### PR DESCRIPTION
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/pub/threads/qMNAqZYN1tXrfXPTNaIrX5GRDyH