### PR TITLE
 Dockerfile: Switch to using base images by arch

### DIFF
--- a/data/Dockerfile.template
+++ b/data/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:14-stretch-run
+FROM balenalib/%%BALENA_ARCH%%-debian-node:14-stretch-run
 
 # Defines our working directory in container
 WORKDIR /usr/src/app

--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:14-stretch-run
+FROM balenalib/%%BALENA_ARCH%%-debian-node:14-stretch-run
 # Defines our working directory in container
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Private DTs do not have base images, we thus switch
to using base images by arch to simplify automated
testing for these devices.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>