### PR TITLE
use bullseye instead of stretch

### DIFF
--- a/data/Dockerfile.template
+++ b/data/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian-node:14-stretch-run
+FROM balenalib/%%BALENA_ARCH%%-debian-node:14-bullseye-run
 
 # Defines our working directory in container
 WORKDIR /usr/src/app

--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian-node:14-stretch-run
+FROM balenalib/%%BALENA_ARCH%%-debian-node:14-bullseye-run
 # Defines our working directory in container
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
switch to bullseye as we no longer generate stretch images as its EOL

Using stretch images meant that we couldn't push to pi0 fleets, as the `balenalib/rpi-debian-node:14-stretch-run` doesn't exist

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>